### PR TITLE
Add HSTS support for our new SSL cert

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,11 +3,13 @@ from flask_mail import Mail
 from flask.ext.mail import Message
 import simplejson
 import os
+from flask_sslify import SSLify
 
 app = Flask(__name__)
 app.config.from_pyfile('config.py')
 mail = Mail(app)
 data = {}
+sslify = SSLify(app)
 
 from config import SECRET_KEY
 from forms import ContactForm

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ simplejson==3.8.1
 virtualenv==12.0.4
 Werkzeug==0.10.4
 WTForms==2.0.2
+flask-sslify==0.1.5


### PR DESCRIPTION
HSTS is a security protocol that goes hand in hand with HTTPS (and therefore our new SSL Cert) to prevent man in the middle attacks. Read more here:https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security

Theres a nice flask associated module that takes care of the implementation for us. I've added it here. 
